### PR TITLE
Support Parent DNS Zone Name without Zone ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# tf-domain
+# tf_domain
+
+Easily define consistent cluster domains on Route53.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ module "domain" {
   namespace            = "example"
   stage                = "dev"
   name                 = "foobar"
-  parent_dns_zone_name = "example.com"
+  parent_zone_name = "example.com"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Easily define consistent cluster domains on Route53.
 
 ## Usage
 
-Define a cluster domain of `foobar.example.com`
+Define a cluster domain of `foobar.example.com` using a custom naming convention for `zone_name`.
+The `zone_name` variable is optional. It defaults to `$${stage}.$${parent_zone_name}`.
 
 ```
 module "domain" {
@@ -12,6 +13,7 @@ module "domain" {
   namespace            = "example"
   stage                = "dev"
   name                 = "foobar"
-  parent_zone_name = "example.com"
+  parent_zone_name     = "example.com"
+  zone_name            = "$${name}.$${stage}.$${parent_zone_name}"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # tf_domain
 
 Easily define consistent cluster domains on Route53.
+
+## Usage
+
+Define a cluster domain of `foobar.example.com`
+
+```
+module "domain" {
+  source               = "git::https://github.com/cloudposse/tf_domain.git?ref=master"
+  namespace            = "example"
+  stage                = "dev"
+  name                 = "foobar"
+  parent_dns_zone_name = "example.com"
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ module "label" {
 
 resource "null_resource" "parent" {
   triggers = {
-    zone_id   = "${format("%v", length(var.parent_zone_id) > data.aws_route53_zone.parent_by_zone_id.zone_id : data.aws_route53_zone.parent_by_zone_name.zone_id )}"
-    zone_name = "${format("%v", length(var.parent_zone_id) > data.aws_route53_zone.parent_by_zone_id.name : data.aws_route53_zone.parent_by_zone_name.name )}"
+    zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? data.aws_route53_zone.parent_by_zone_id.zone_id : data.aws_route53_zone.parent_by_zone_name.zone_id )}"
+    zone_name = "${format("%v", length(var.parent_zone_id) > 0 ? data.aws_route53_zone.parent_by_zone_id.name : data.aws_route53_zone.parent_by_zone_name.name )}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git"
+  source = "git::https://github.com/cloudposse/tf_label.git?ref=master"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"
@@ -13,12 +13,7 @@ data "aws_route53_zone" "parent" {
 
 resource "aws_route53_zone" "default" {
   name = "${var.stage}.${data.aws_route53_zone.parent.name}"
-
-  tags {
-    Name      = "${module.label.id}"
-    Namespace = "${var.namespace}"
-    Stage     = "${var.stage}"
-  }
+  tags = "${module.label.tags}"
 }
 
 resource "aws_route53_record" "ns" {

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,18 @@ module "label" {
   stage     = "${var.stage}"
 }
 
+data "template_file" "zone_name" {
+  template = "${var.zone_name}"
+
+  vars {
+    namespace        = "${var.namespace}"
+    name             = "${var.name}"
+    stage            = "${var.stage}"
+    id               = "${module.label.id}"
+    parent_zone_name = "${null_resource.parent.triggers.zone_name}"
+  }
+}
+
 resource "null_resource" "parent" {
   triggers = {
     zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.zone_id) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.zone_id) )}"
@@ -28,7 +40,7 @@ data "aws_route53_zone" "parent_by_zone_name" {
 }
 
 resource "aws_route53_zone" "default" {
-  name = "${var.stage}.${null_resource.parent.triggers.zone_name}"
+  name = "${data.template_file.zone_name.output}"
   tags = "${module.label.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ module "label" {
 
 data "aws_route53_zone" "parent" {
   zone_id = "${var.parent_zone_id}"
+  name = "${var.parent_zone_name}"
 }
 
 resource "aws_route53_zone" "default" {

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ module "label" {
 
 resource "null_resource" "parent" {
   triggers = {
-    zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? data.aws_route53_zone.parent_by_zone_id.zone_id : data.aws_route53_zone.parent_by_zone_name.zone_id )}"
-    zone_name = "${format("%v", length(var.parent_zone_id) > 0 ? data.aws_route53_zone.parent_by_zone_id.name : data.aws_route53_zone.parent_by_zone_name.name )}"
+    zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.zone_id) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.zone_id) )}"
+    zone_name = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.name) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.name) )}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ data "aws_route53_zone" "parent_by_zone_name" {
 }
 
 resource "aws_route53_zone" "default" {
-  name = "${data.template_file.zone_name.output}"
+  name = "${data.template_file.zone_name.rendered}"
   tags = "${module.label.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source = "git::https://github.com/cloudposse/tf_label.git?ref=master"
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=master"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"
@@ -16,14 +16,15 @@ resource "null_resource" "parent" {
     create_before_destroy = true
   }
 }
+
 data "aws_route53_zone" "parent_by_zone_id" {
-  count = "${signum(length(var.parent_zone_id))}"
+  count   = "${signum(length(var.parent_zone_id))}"
   zone_id = "${var.parent_zone_id}"
 }
 
 data "aws_route53_zone" "parent_by_zone_name" {
   count = "${signum(length(var.parent_zone_name))}"
-  name = "${var.parent_zone_name}"
+  name  = "${var.parent_zone_name}"
 }
 
 resource "aws_route53_zone" "default" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "label" {
 }
 
 data "template_file" "zone_name" {
-  template = "${var.zone_name}"
+  template = "${replace(var.zone_name, "$$$$", "$")}"
 
   vars {
     namespace        = "${var.namespace}"

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "ns" {
-  zone_id = "${var.parent_zone_id}"
+  zone_id = "${data.aws_route53_zone.parent.zone_id}"
   name    = "${aws_route53_zone.default.name}"
   type    = "NS"
   ttl     = "60"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "parent_zone_id" {
-  value = "${data.aws_route53_zone.parent.zone_id}"
+  value = "${null_resource.parent.triggers.zone_id}"
 }
 
 output "parent_zone_name" {
-  value = "${data.aws_route53_zone.parent.name}"
+  value = "${null_resource.parent.triggers.zone_name}"
 }
 
 output "zone_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,10 @@ output "zone_id" {
   value = "${aws_route53_zone.default.zone_id}"
 }
 
+output "zone_name" {
+  value = "${aws_route53_zone.default.name}"
+}
+
 output "fqdn" {
   value = "${aws_route53_zone.default.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,11 @@
+output "parent_zone_id" {
+  value = "${data.aws_route53_zone.parent.zone_id}"
+}
+
+output "parent_zone_name" {
+  value = "${data.aws_route53_zone.parent.name}"
+}
+
 output "zone_id" {
   value = "${aws_route53_zone.default.zone_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "zone_id" {
 }
 
 output "zone_name" {
-  value = "${replace(aws_route53_zone.default.name, "/\.$/", ""}"
+  value = "${replace(aws_route53_zone.default.name, "/\.$/", "")}"
 }
 
 output "fqdn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "zone_id" {
 }
 
 output "zone_name" {
-  value = "${aws_route53_zone.default.name}"
+  value = "${replace(aws_route53_zone.default.name, "/\.$/", ""}"
 }
 
 output "fqdn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "zone_id" {
 }
 
 output "zone_name" {
-  value = "${replace(aws_route53_zone.default.name, "/\.$/", "")}"
+  value = "${replace(aws_route53_zone.default.name, "/\\.$$/", "")}"
 }
 
 output "fqdn" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,10 @@ variable "name" {
   default = "domain"
 }
 
+variable "zone_name" {
+  default = "$${stage}.$${parent_zone_name}"
+}
+
 variable "parent_zone_id" {
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,10 @@ variable "parent_zone_id" {
   default = ""
 }
 
+variable "parent_zone_name" {
+  default = ""
+}
+
 variable "ttl" {
   default = "300"
 }


### PR DESCRIPTION
## what
* Support DNS Zone creation using only parent DNS Zone (without ID)
* Support custom zone templates; default to `$${stage}.$${parent_zone_name}`

## why
* Much easier to only pass in the parent's DNS Zone name (e.g. foobar.com)
* Support arbitrary zone name conventions

