### PR TITLE
Remove name, namespace and stage default values from `tf_domain`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,8 @@
-variable "namespace" {
-  default = "global"
-}
+variable "namespace" {}
 
-variable "stage" {
-  default = "default"
-}
+variable "stage" {}
 
-variable "name" {
-  default = "domain"
-}
+variable "name" {}
 
 variable "zone_name" {
   default = "$${stage}.$${parent_zone_name}"


### PR DESCRIPTION
## What
* Remove default values for  `name`, `namespace` and `stage` variables

## Why
* This needs to avoid names collision in case we use `default values`, if a module would control name of a created resource
