### PR TITLE
feat: private route53 zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ module "domain" {
 | <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | ID of the hosted zone to contain this record  (or specify `parent_zone_name`) | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | `string` | `""` | no |
 | <a name="input_parent_zone_record_enabled"></a> [parent\_zone\_record\_enabled](#input\_parent\_zone\_record\_enabled) | Whether to create the NS record on the parent zone. Useful for creating a cluster zone across accounts. `var.parent_zone_name` required if set to false. | `bool` | `true` | no |
+| <a name="input_private_hosted_zone_vpc_attachments"></a> [private\_hosted\_zone\_vpc\_attachments](#input\_private\_hosted\_zone\_vpc\_attachments) | If creating a private hosted zone, the VPC to attach to. | <pre>list(object({<br/>    vpc_id     = string<br/>    vpc_region = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_soa_record_ttl"></a> [soa\_record\_ttl](#input\_soa\_record\_ttl) | The time to live (TTL) of the Start of Authority Route53 record, in seconds.<br/>This sets the maximum time a negative (no data) query can be cached.<br/><br/>The default value is short for responsiveness to changes during development and <br/>is not recommended for production. Typical production values are in the range of 300 to 3600. | `number` | `30` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
@@ -142,6 +143,7 @@ module "domain" {
 | <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | Fully-qualified domain name |
 | <a name="output_parent_zone_id"></a> [parent\_zone\_id](#output\_parent\_zone\_id) | ID of the hosted zone to contain this record |
 | <a name="output_parent_zone_name"></a> [parent\_zone\_name](#output\_parent\_zone\_name) | Name of the hosted zone to contain this record |
+| <a name="output_private_zone"></a> [private\_zone](#output\_private\_zone) | n/a |
 | <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Route53 DNS Zone ID |
 | <a name="output_zone_name"></a> [zone\_name](#output\_zone\_name) | Route53 DNS Zone name |
 | <a name="output_zone_name_servers"></a> [zone\_name\_servers](#output\_zone\_name\_servers) | Route53 DNS Zone Name Servers |

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   enabled                    = module.this.enabled ? 1 : 0
   parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled ? 1 : 0
   zone_name                  = local.parent_zone_record_enabled == 1 ? var.zone_name : replace(var.zone_name, ".$${parent_zone_name}", "")
+  private_zone               = length(var.private_hosted_zone_vpc_attachments) == 0 ? false : true
 }
 
 data "aws_region" "default" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,7 @@ output "fqdn" {
   value       = join("", aws_route53_zone.default.*.name)
   description = "Fully-qualified domain name"
 }
+
+output "private_zone" {
+  value = local.private_zone
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,12 @@ variable "soa_record_ttl" {
     is not recommended for production. Typical production values are in the range of 300 to 3600.
     EOT
 }
+
+variable "private_hosted_zone_vpc_attachments" {
+  type = list(object({
+    vpc_id     = string
+    vpc_region = string
+  }))
+  default     = []
+  description = "If creating a private hosted zone, the VPC to attach to."
+}


### PR DESCRIPTION
## what

brings https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/52 up to date with latest master
allow creation of private hosted zones for internal network @kevcube
Misc: no longer support AWS Provider 2.x @korenyoni

## why

https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/52 has merge conflicts
I want to put my database hostnames inside private DNS @kevcube
Misc: We are now one major version ahead of AWS Provider 2.x. @kevcube

## references

[terraform route53 hosted zone docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone#vpc_id)
Closes https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/52
Based on https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/56 Kudos to @jbcom
Includes https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/56#pullrequestreview-1194711208 and https://github.com/cloudposse/terraform-aws-route53-cluster-zone/pull/56#pullrequestreview-1194711341
